### PR TITLE
Fix controllers

### DIFF
--- a/fix-metainfo-1.5.0.patch
+++ b/fix-metainfo-1.5.0.patch
@@ -88,10 +88,10 @@ index e31dddbb3..acba3edba 100644
 +      Note: DevilutionX requires data files from original Diablo/Hellfire. By default, a demo version of Diablo is installed.
 +		</p>
 +		<p>
-+	  To install the full version of Diablo, copy <em>DIABDAT.MPQ</em> from the CD or GOG-installation (or extract it from the GoG installer) to <code>~/.var/app/org.diasurgical.DevilutionX/data/diasurgical/devilution</code>.
++	  To install the full version of Diablo, copy DIABDAT.MPQ from the CD or GOG-installation (or extract it from the GoG installer) to ~/.var/app/org.diasurgical.DevilutionX/data/diasurgical/devilution.
 +		</p>
 +		<p>
-+	  To run the Diablo: Hellfire expansion you will need to also copy <em>hellfire.mpq</em>, <em>hfmonk.mpq</em>, <em>hfmusic.mpq</em>, <em>hfvoice.mpq</em>.
++	  To run the Diablo: Hellfire expansion you will need to also copy hellfire.mpq, hfmonk.mpq, hfmusic.mpq, hfvoice.mpq.
 +		</p>
 +	</description>
 +

--- a/org.diasurgical.DevilutionX.yml
+++ b/org.diasurgical.DevilutionX.yml
@@ -11,6 +11,8 @@ finish-args:
     - --socket=fallback-x11
     - --socket=wayland
     - --device=dri
+    # Required for controllers to work
+    - --device=all
     - --share=network
     - --share=ipc
     - --socket=pulseaudio


### PR DESCRIPTION
Adds "--device=all" permission, without it controllers don't work
Also removes `<em>` and `<code>` tags from description, since they don't render in Flathub or the stores, even though Appstream docs claim support