### PR TITLE
Add proper permission for controllers

### DIFF
--- a/org.diasurgical.DevilutionX.yml
+++ b/org.diasurgical.DevilutionX.yml
@@ -10,8 +10,8 @@ rename-icon: devilutionx
 finish-args:
     - --socket=fallback-x11
     - --socket=wayland
-    # Required for controllers to work
-    - --device=all
+    - --device=dri
+    - --device=input
     - --share=network
     - --share=ipc
     - --socket=pulseaudio


### PR DESCRIPTION
Turns out this has been available since 2023
https://github.com/flatpak/flatpak/pull/5481
This gets rid of overly permissive `device=all`