### PR TITLE
Build in separate build folder

### DIFF
--- a/org.diasurgical.DevilutionX.yml
+++ b/org.diasurgical.DevilutionX.yml
@@ -19,6 +19,8 @@ modules:
   - name: devilutionX
     buildsystem: cmake-ninja
     config-opts:
+      - -S .
+      - -B build
       - -DBUILD_TESTING=OFF
       - -DCMAKE_BUILD_TYPE=Release
     sources:


### PR DESCRIPTION
Prevents a warning about in-source build