### PR TITLE
Clarify license from custom to SPDX tag

### DIFF
--- a/fix-metainfo-1.5.5.patch
+++ b/fix-metainfo-1.5.5.patch
@@ -1,22 +1,32 @@
 diff --git a/Packaging/nix/devilutionx.metainfo.xml b/Packaging/nix/devilutionx.metainfo.xml
-index 0c607f2ce..666d14167 100644
+index 0c607f2ce..db50b9f4c 100644
 --- a/Packaging/nix/devilutionx.metainfo.xml
 +++ b/Packaging/nix/devilutionx.metainfo.xml
-@@ -76,6 +76,20 @@
+@@ -10,7 +10,7 @@
+ 	<summary>Experience Diablo and Hellfire anew</summary>
+ 
+ 	<metadata_license>CC-BY-SA-4.0</metadata_license>
+-	<project_license>LicenseRef-scancode-sustainable-use-1.0=https://scancode-licensedb.aboutcode.org/sustainable-use-1.0.html</project_license>
++	<project_license>SUL-1.0</project_license>
+ 
+ 	<branding>
+ 		<color type="primary" scheme_preference="light">#c86666</color>
+@@ -76,6 +76,21 @@
  		</screenshot>
  	</screenshots>
  	<releases>
 +		<release version="1.5.5" date="2025-10-31">
 +			<description>
-+			<p>This release includes the following updates:</p>
-+			<ul>
-+				<li>App icon on Linux is now aligned with Android</li>
-+				<li>Adjusted game speeds for Multiplayer</li>
-+				<li>You can now use CTRL+ Mouse Scroll to zoom the map</li>
-+				<li>Murphy Shrine has been added to Crippling Shrines</li>
-+				<li>Updates to Russian and Polish translations</li>
-+				<li>Crash fixes</li>
-+			</ul>
++				<p>This release includes the following updates:</p>
++				<ul>
++					<li>App icon on Linux is now aligned with Android</li>
++					<li>Adjusted game speeds for Multiplayer</li>
++					<li>You can now use CTRL+ Mouse Scroll to zoom the map</li>
++					<li>Murphy Shrine has been added to Crippling Shrines</li>
++					<li>Updates to Russian and Polish translations</li>
++					<li>Crash fixes</li>
++				</ul>
++				<p>Please visit the full changelog for more detailed notes</p>
 +			</description>
 +			<url>https://github.com/diasurgical/devilutionX/releases/tag/1.5.5</url>
 +		</release>


### PR DESCRIPTION
Now, that Sustainable License has been added to SPDX since July 2025, we can use its tag, instead of the custom license.

This will (hopefully) prevent the app showing up as proprietary in Flathub